### PR TITLE
I've added enhanced logging to the OpenWebUI startup process.

### DIFF
--- a/open-webui-public/open-webui-public/backend/start.sh
+++ b/open-webui-public/open-webui-public/backend/start.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR" || exit
 
@@ -65,4 +67,5 @@ if [ -n "$SPACE_ID" ]; then
   export WEBUI_URL=${SPACE_HOST}
 fi
 
-WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'
+echo "Attempting to start Uvicorn with debug logging..."
+WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' --log-level debug > /app/backend/data/uvicorn.log 2>&1


### PR DESCRIPTION
This involves modifying the `backend/start.sh` script to improve diagnostics for situations where the Uvicorn server doesn't start correctly.

Here are the key changes I made:
- I added `set -x` to the beginning of `start.sh` so you can see which commands are being run.
- I modified the Uvicorn execution command to:
    - Log more detailed information (`--log-level debug`).
    - Save all output (both standard output and errors) to `/app/backend/data/uvicorn.log`.
    - I also added a message that will appear right before Uvicorn starts.

These adjustments will help capture detailed error messages if the FastAPI application runs into problems during its initial setup. This is something I suspect might be causing the 'unhealthy' status and issues with accessing the port. The logs will be saved in the `open-webui` volume, making them easier for you to access.